### PR TITLE
fix(scaffolding, readme): reflex current project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Steps
 
-- You can put your json in `public/data/` and edit the value of `endpoint_url` in `config.ts`. Currently you also need to have a dummy `endpoints.json` inside `src/data/`, but we're working on removing that need.
+- You can put your json in `public/data/` and edit the value of `endpoint_url` in `config.ts`.
 
 - If your json dont have this structure you can edit the `generateData()` function in `generateData.ts` and make sure the output satisfy the typescript interface `Endpoint`. This is a implementation of a strategy pattern to allow you use this project with any json structure of your api schema, not only a OpenAPI structure.
 

--- a/src/compositions/DocumentationApp/Navigation/index.stories.tsx
+++ b/src/compositions/DocumentationApp/Navigation/index.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import Navigation from ".";
 import { Endpoint } from "../../../types";
-import data from "../../../data/endpoints.json";
-import generateData from "../../../mocks/generateData";
+import CreateDoc from "../../../lib/CreateDoc";
+import config from "../../../mocks/config";
 
 export default {
   title: "Navigation",
@@ -10,6 +10,6 @@ export default {
 };
 
 export const simpleExample: React.FC = () => {
-  const endpoints: Endpoint[] = generateData(data);
+  const endpoints: Endpoint[] = CreateDoc(config);
   return <Navigation endpoints={endpoints} />;
 };

--- a/src/compositions/DocumentationApp/index.stories.tsx
+++ b/src/compositions/DocumentationApp/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import DocumentationApp from ".";
-import data from "../../data/endpoints.json";
-import generateData from "../../mocks/generateData";
+import CreateDoc from "../../lib/CreateDoc";
+import config from "../../mocks/config";
 import { SearchProvider } from "../../providers/SearchProvider";
 
 export default {
@@ -11,5 +11,5 @@ export default {
 };
 
 export const simpleExample: React.FC = () => (
-  <DocumentationApp data={generateData(data)} />
+  <DocumentationApp data={CreateDoc(config)} />
 );

--- a/src/lib/CreateDoc.ts
+++ b/src/lib/CreateDoc.ts
@@ -6,7 +6,7 @@ import Render from "./Render";
  * or/and render ui or catch error
  * @param config have all configutation to create the documentation
  */
-const CreateDoc = (config: Config): void => {
+const CreateDoc = (config: Config): any => {
   if (config.endpoint_url) {
     fetch(config.endpoint_url)
       .then((res) => {


### PR DESCRIPTION
keep `public/data/` instead of `src/data/`, as the JSON documents now reside in that directory

`src/compositions/`: use the new document generation method

`src/lib/CreateDoc.ts`: fix return type to ease its use in `src/compositions/`

`README.md`: remove the note about the need of a `src/data/endpoints.json`