### PR TITLE
[SKIP CI] fix(README): use new all-contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Generator of API REST Documentation
 [![Build Status](https://travis-ci.org/CharlyJazz/API-REST-Documentation-Generator.svg?branch=master)](https://travis-ci.org/CharlyJazz/API-REST-Documentation-Generator)
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![All Contributors](https://img.shields.io/github/all-contributors/CharlyJazz/API-REST-Documentation-Generator)](#contributors-)
 
 - The point of this project is provide to the devs a structure and logical flow to create a REST API documentation without swagger or other tool. Why? I dont know. :star:. But you can use it instead install gems or packages to your backend project, Why? I dont know :star2:
 


### PR DESCRIPTION
According to [1], the pattern used by the all-contributors bot to find
and update the badge makes impossible inlining the badges due to the way
comments are rendered in markdown. In response to that, in [2] a new(er)
badge that doesn't need to be manually updated by the bot was made.
Still, from the status of [3] it seems the cli (which apparently powers the
API used by the bot) has yet to be updated to use it.

Fixes #41

[1] all-contributors/all-contributors#361
[2] all-contributors/all-contributors#406
[3] all-contributors/all-contributors-cli#266